### PR TITLE
Small fixed to template class and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ignore OS X auxiliary files
+*.DS_Store
+
 *.vtu
 *.vtk
 *.pvtu

--- a/include/interfaces/template.h
+++ b/include/interfaces/template.h
@@ -157,7 +157,7 @@ set_energies_and_residuals(const typename DoFHandler<dim,spacedim>::active_cell_
         {
           auto v = fev[displacement] .value(i,q); // test function
 
-          local_residuals[0] -= 0.1*v*u;
+          local_residuals[0][i] -= 0.1*v*u;
 
           // matrix[0] is assumed to be the system matrix other
           // matrices are either preconditioner or auxiliary matrices
@@ -166,7 +166,7 @@ set_energies_and_residuals(const typename DoFHandler<dim,spacedim>::active_cell_
           // if this function is called to evalute the system residual
           //  we do not need to assemble them so we guard them
           if (!compute_only_system_matrix)
-            local_residuals[1] += v*u;
+            local_residuals[1][i] += v*u;
         }
     }
 

--- a/include/interfaces/template.h
+++ b/include/interfaces/template.h
@@ -157,7 +157,7 @@ set_energies_and_residuals(const typename DoFHandler<dim,spacedim>::active_cell_
         {
           auto v = fev[displacement] .value(i,q); // test function
 
-          local_residuals[0][i] -= 0.1*v*u;
+          local_residuals[0][i] -= 0.1*v*u*JxW[q];
 
           // matrix[0] is assumed to be the system matrix other
           // matrices are either preconditioner or auxiliary matrices
@@ -166,7 +166,7 @@ set_energies_and_residuals(const typename DoFHandler<dim,spacedim>::active_cell_
           // if this function is called to evalute the system residual
           //  we do not need to assemble them so we guard them
           if (!compute_only_system_matrix)
-            local_residuals[1][i] += v*u;
+            local_residuals[1][i] += v*u*JxW[q];
         }
     }
 


### PR DESCRIPTION
Small modification to the template interface when building the residuals.
Also added .DS_STORE files to the .gitignore. Mac OS X creates these files everywhere and they do not need to be loaded to the online repository.
