### PR TITLE
fix calling to interface.connect_to_signals()

### DIFF
--- a/source/pidomus.cc
+++ b/source/pidomus.cc
@@ -131,7 +131,6 @@ piDoMUS<dim, spacedim, LAC>::piDoMUS (const std::string &name,
 
   interface.initialize_simulator (*this);
 
-  interface.connect_to_signals();
 
   for (unsigned int i=0; i<n_matrices; ++i)
     {
@@ -861,6 +860,9 @@ template <int dim, int spacedim, typename LAC>
 void piDoMUS<dim, spacedim, LAC>::run ()
 {
   interface.set_stepper(time_stepper);
+
+  interface.connect_to_signals();
+
   for (current_cycle = 0; current_cycle < n_cycles; ++current_cycle)
     {
       if (current_cycle == 0)


### PR DESCRIPTION
before the function `interface.connect_to_signals()` was called inside the constructor of pi-DoMUS **before** that `ParameterAcceptor::Initilize` was called. Therefore, we could not rely on the values of parameters inside the `connect_to_signals()` function. This PR fixes this calling `connect_to_signals()` at the begin of `pi-DoMUS::run()`
