### PR TITLE
piDoMUS is no longer derived from SundialsInterface

### DIFF
--- a/include/base_interface.h
+++ b/include/base_interface.h
@@ -399,7 +399,11 @@ public:
   */
   void set_stepper(const std::string &s) const;
 
-
+  /**
+    * Return norm of vector @p v. This function is called by the IMEX stepper.
+    * By default it returns the l2 norm.
+    */
+  virtual double vector_norm(const typename LAC::VectorType &v) const;
 
 protected:
 

--- a/include/lac/lac_type.h
+++ b/include/lac/lac_type.h
@@ -17,7 +17,7 @@
 
 
 #include <deal.II/base/config.h>
-
+#include <deal2lkit/config.h>
 
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/block_vector.h>
@@ -28,7 +28,7 @@
 #include <deal.II/lac/precondition.h>
 
 using namespace dealii;
-using namespace deal2lkit;
+//using namespace deal2lkit;
 
 class LADealII
 {

--- a/include/pidomus.h
+++ b/include/pidomus.h
@@ -34,6 +34,8 @@
 #include "base_interface.h"
 #include "simulator_access.h"
 #include "pidomus_signals.h"
+#include "pidomus_lambdas.h"
+
 
 #include <deal2lkit/parsed_grid_generator.h>
 #include <deal2lkit/parsed_finite_element.h>
@@ -72,7 +74,7 @@ public:
 
   piDoMUS (const std::string &name,
            const BaseInterface<dim, spacedim, LAC> &energy,
-           const MPI_Comm &comm = MPI_COMM_WORLD);
+           const MPI_Comm comm = MPI_COMM_WORLD);
 
   virtual void declare_parameters(ParameterHandler &prm);
   virtual void parse_parameters_call_back();
@@ -307,7 +309,7 @@ private:
 
   void set_constrained_dofs_to_zero(typename LAC::VectorType &v) const;
 
-  const MPI_Comm &comm;
+  const MPI_Comm comm;
   const BaseInterface<dim, spacedim, LAC>    &interface;
 
   unsigned int n_cycles;
@@ -436,7 +438,7 @@ private:
 
 
   IDAInterface<typename LAC::VectorType>  ida;
-  IMEXStepper<typename LAC::VectorType> euler;
+  IMEXStepper<typename LAC::VectorType> imex;
 
 
   std::vector<types::global_dof_index> dofs_per_block;
@@ -532,6 +534,12 @@ private:
    * const reference to them through functions named get_variable()
    */
   friend class SimulatorAccess<dim,spacedim,LAC>;
+
+public:
+
+  friend class Lambdas<dim,spacedim,LAC>;
+
+  Lambdas<dim,spacedim,LAC> lambdas;
 
 };
 

--- a/include/pidomus.h
+++ b/include/pidomus.h
@@ -311,7 +311,6 @@ private:
   unsigned int n_cycles;
   unsigned int current_cycle;
   unsigned int initial_global_refinement;
-  unsigned int max_time_iterations;
 
   ConditionalOStream        pcout;
 

--- a/include/pidomus.h
+++ b/include/pidomus.h
@@ -43,7 +43,6 @@
 #include <deal2lkit/error_handler.h>
 #include <deal2lkit/parsed_function.h>
 #include <deal2lkit/parameter_acceptor.h>
-#include <deal2lkit/sundials_interface.h>
 #include <deal2lkit/ida_interface.h>
 #include <deal2lkit/imex_stepper.h>
 #include <deal2lkit/parsed_zero_average_constraints.h>
@@ -61,7 +60,7 @@ using namespace deal2lkit;
 using namespace pidomus;
 
 template <int dim, int spacedim = dim, typename LAC = LATrilinos>
-class piDoMUS : public ParameterAcceptor, public SundialsInterface<typename LAC::VectorType>
+class piDoMUS : public ParameterAcceptor
 {
 
 
@@ -98,8 +97,7 @@ public:
   virtual void output_step(const double t,
                            const typename LAC::VectorType &solution,
                            const typename LAC::VectorType &solution_dot,
-                           const unsigned int step_number,
-                           const double h);
+                           const unsigned int step_number);
 
   /** Check the behaviour of the solution. If it
    * is converged or if it is becoming unstable the time integrator
@@ -107,8 +105,6 @@ public:
    * calculation will be continued. If necessary, it can also reset
    * the time stepper. */
   virtual bool solver_should_restart(const double t,
-                                     const unsigned int step_number,
-                                     const double h,
                                      typename LAC::VectorType &solution,
                                      typename LAC::VectorType &solution_dot);
 
@@ -123,17 +119,11 @@ public:
   virtual int setup_jacobian(const double t,
                              const typename LAC::VectorType &src_yy,
                              const typename LAC::VectorType &src_yp,
-                             const typename LAC::VectorType &residual,
                              const double alpha);
 
 
   /** Inverse of the Jacobian vector product. */
-  virtual int solve_jacobian_system(const double t,
-                                    const typename LAC::VectorType &y,
-                                    const typename LAC::VectorType &y_dot,
-                                    const typename LAC::VectorType &residual,
-                                    const double alpha,
-                                    const typename LAC::VectorType &src,
+  virtual int solve_jacobian_system(const typename LAC::VectorType &src,
                                     typename LAC::VectorType &dst) const;
 
   /**

--- a/include/pidomus.h
+++ b/include/pidomus.h
@@ -70,10 +70,14 @@ class piDoMUS : public ParameterAcceptor
 
 public:
 
-
+#ifdef DEAL_II_WITH_MPI
   piDoMUS (const std::string &name,
            const BaseInterface<dim, spacedim, LAC> &energy,
            const MPI_Comm comm = MPI_COMM_WORLD);
+#else
+  piDoMUS (const std::string &name,
+           const BaseInterface<dim, spacedim, LAC> &energy);
+#endif
 
   virtual void declare_parameters(ParameterHandler &prm);
   virtual void parse_parameters_call_back();
@@ -299,7 +303,9 @@ private:
 
   void set_constrained_dofs_to_zero(typename LAC::VectorType &v) const;
 
+#ifdef DEAL_II_WITH_MPI
   const MPI_Comm comm;
+#endif
   const BaseInterface<dim, spacedim, LAC>    &interface;
 
   unsigned int n_cycles;
@@ -513,6 +519,12 @@ private:
                   const typename LAC::VectorType &solution,
                   const typename LAC::VectorType &solution_dot);
 
+
+  /**
+   * Return the norm of vector @p v. Internally it calls the
+   * virtual function BaseInterface::vector_norm().
+   */
+  double vector_norm(const typename LAC::VectorType &v) const;
 
   /**
    * Struct containing the signals

--- a/include/pidomus_lambdas.h
+++ b/include/pidomus_lambdas.h
@@ -69,13 +69,17 @@ public:
    */
   std::function<shared_ptr<typename LAC::VectorType>()> create_new_vector;
 
-  /** Compute residual. */
+  /**
+   * Compute residual.
+   */
   std::function<int(const double t,
                     const typename LAC::VectorType &y,
                     const typename LAC::VectorType &y_dot,
                     typename LAC::VectorType &res)> residual;
 
-  /** Compute Jacobian. */
+  /**
+   * Compute Jacobian.
+   */
   std::function<int(const double t,
                     const typename LAC::VectorType &y,
                     const typename LAC::VectorType &y_dot,
@@ -93,7 +97,7 @@ public:
                       const unsigned int step_number)> output_step;
 
   /**
-   * Evaluate if the mesh should be refined or not. If so,
+   * Evaluate wether the mesh should be refined or not. If so,
    * it refines and interpolate the solutions from the old to the
    * new mesh.
    */
@@ -110,7 +114,7 @@ public:
 
   /**
    * Return a vector whose components are the weights used by
-   * IDA to compute the norm. By default this function is not
+   * IDA to compute the vector norm. By default this function is not
    * implemented.
    */
   std::function<typename LAC::VectorType&()> get_local_tolerances;
@@ -124,10 +128,15 @@ public:
 
   /**
    * Compute the matrix-vector product Jacobian times @p src,
-   * and the result is put in @p dst.
+   * and the result is put in @p dst. It is required by Kinsol.
    */
   std::function<int(const typename LAC::VectorType &src,
                     typename LAC::VectorType &dst)> jacobian_vmult;
+
+  /**
+   * Return the norm of @p vector, which is used by IMEXStepper.
+   */
+  std::function<double(const typename LAC::VectorType &vector)> vector_norm;
 
   /**
    * A pointer to the simulator object to which we want to get

--- a/include/pidomus_lambdas.h
+++ b/include/pidomus_lambdas.h
@@ -1,0 +1,93 @@
+#ifndef __pidomus_lambdas_h_
+#define __pidomus_lambdas_h_
+
+#include "lac/lac_type.h"
+#include <deal2lkit/utilities.h>
+
+using namespace deal2lkit;
+// forward declaration
+template <int dim, int spacedim, typename LAC> class piDoMUS;
+
+template <int dim, int spacedim, typename LAC>
+class Lambdas
+{
+public:
+
+  /**
+   * Default constructor. Initialize the Lambdas object without
+   * a reference to a particular piDoMUS object. You will later have
+   * to call initialize() to provide this reference to the piDoMUS
+   * object.
+   */
+  Lambdas ();
+
+  /**
+   * Create a Lambdas object that is already initialized for
+   * a particular piDoMUS.
+   */
+  Lambdas (piDoMUS<dim,spacedim,LAC> &simulator_object);
+
+  /**
+   * Destructor. Does nothing but is virtual so that derived classes
+   * destructors are also virtual.
+   */
+  virtual
+  ~Lambdas ();
+
+  /**
+   * Initialize this class for a given simulator. This function is marked
+   * as virtual so that derived classes can do something upon
+   * initialization as well, for example look up and cache data; derived
+   * classes should call this function from the base class as well,
+   * however.
+   *
+   * @param simulator_object A reference to the main simulator object.
+   */
+  virtual void initialize_simulator (piDoMUS<dim, spacedim, LAC> &simulator_object);
+
+  /**
+   * Set the default behavior of the functions of this class,
+   * which is call the namesake functions of the simulator_bject.
+   */
+  void set_functions_to_default();
+
+  std::function<shared_ptr<typename LAC::VectorType>()> create_new_vector;
+
+  /** standard function computing residuals */
+  std::function<int(const double t,
+                    const typename LAC::VectorType &y,
+                    const typename LAC::VectorType &y_dot,
+                    typename LAC::VectorType &res)> residual;
+
+  /** standard function computing the Jacobian */
+  std::function<int(const double t,
+                    const typename LAC::VectorType &y,
+                    const typename LAC::VectorType &y_dot,
+                    const double alpha)> setup_jacobian;
+
+  /** standard function solving linear system */
+  std::function<int(const typename LAC::VectorType &rhs, typename LAC::VectorType &dst)> solve_jacobian_system;
+
+  std::function<void (const double t,
+                      const typename LAC::VectorType &sol,
+                      const typename LAC::VectorType &sol_dot,
+                      const unsigned int step_number)> output_step;
+
+  std::function<bool (const double t,
+                      typename LAC::VectorType &sol,
+                      typename LAC::VectorType &sol_dot)> solver_should_restart;
+
+  std::function<typename LAC::VectorType&()> differential_components;
+
+  std::function<typename LAC::VectorType&()> get_local_tolerances;
+
+  std::function<typename LAC::VectorType&()> get_lumped_mass_matrix;
+
+  /**
+   * A pointer to the simulator object to which we want to get
+   * access.
+   */
+  piDoMUS<dim,spacedim,LAC> *simulator;
+};
+
+#endif

--- a/include/pidomus_lambdas.h
+++ b/include/pidomus_lambdas.h
@@ -8,6 +8,24 @@ using namespace deal2lkit;
 // forward declaration
 template <int dim, int spacedim, typename LAC> class piDoMUS;
 
+/**
+ * Lambdas class. A piDoMUS object has a Lambdas object and the
+ * std::functions of the provided stepper (e.g., ida, imex)
+ * are set to be equal to those here implemented.
+ *
+ * By default, the std::functions of this class call the
+ * namesake functions of the piDoMUS object, which is specified
+ * either when the Lambdas object is constructed or by calling the
+ * Lambdas::initialize_simulator() function.
+ *
+ * The aim of this class is to increase the flexibility of piDoMUS.
+ * piDoMUS offers flexibility by itself thanks to the signals
+ * to whom the user can connect in order to perform problem-specific
+ * tasks. Whether the behavior of a function should be completely different,
+ * the user can ovveride the functions declared here (without the need
+ * of modifying piDoMUS' source code).
+ */
+
 template <int dim, int spacedim, typename LAC>
 class Lambdas
 {
@@ -28,22 +46,16 @@ public:
   Lambdas (piDoMUS<dim,spacedim,LAC> &simulator_object);
 
   /**
-   * Destructor. Does nothing but is virtual so that derived classes
-   * destructors are also virtual.
+   * Destructor. Does nothing.
    */
-  virtual
   ~Lambdas ();
 
   /**
-   * Initialize this class for a given simulator. This function is marked
-   * as virtual so that derived classes can do something upon
-   * initialization as well, for example look up and cache data; derived
-   * classes should call this function from the base class as well,
-   * however.
+   * Initialize this class for a given simulator.
    *
    * @param simulator_object A reference to the main simulator object.
    */
-  virtual void initialize_simulator (piDoMUS<dim, spacedim, LAC> &simulator_object);
+  void initialize_simulator (piDoMUS<dim, spacedim, LAC> &simulator_object);
 
   /**
    * Set the default behavior of the functions of this class,
@@ -51,38 +63,69 @@ public:
    */
   void set_functions_to_default();
 
+  /**
+   * Return a shared_ptr<VECTOR_TYPE>. A shared_ptr is needed in order to
+   * keep the pointed vector alive, without the need to use a static variable.
+   */
   std::function<shared_ptr<typename LAC::VectorType>()> create_new_vector;
 
-  /** standard function computing residuals */
+  /** Compute residual. */
   std::function<int(const double t,
                     const typename LAC::VectorType &y,
                     const typename LAC::VectorType &y_dot,
                     typename LAC::VectorType &res)> residual;
 
-  /** standard function computing the Jacobian */
+  /** Compute Jacobian. */
   std::function<int(const double t,
                     const typename LAC::VectorType &y,
                     const typename LAC::VectorType &y_dot,
                     const double alpha)> setup_jacobian;
 
-  /** standard function solving linear system */
+  /** Solve linear system. */
   std::function<int(const typename LAC::VectorType &rhs, typename LAC::VectorType &dst)> solve_jacobian_system;
 
+  /**
+   * Store solutions to file.
+   */
   std::function<void (const double t,
                       const typename LAC::VectorType &sol,
                       const typename LAC::VectorType &sol_dot,
                       const unsigned int step_number)> output_step;
 
+  /**
+   * Evaluate if the mesh should be refined or not. If so,
+   * it refines and interpolate the solutions from the old to the
+   * new mesh.
+   */
   std::function<bool (const double t,
                       typename LAC::VectorType &sol,
                       typename LAC::VectorType &sol_dot)> solver_should_restart;
 
+  /**
+   * Return a vector whose component are 1 if the corresponding
+   * dof is differential, 0 if algebraic. This function is needed
+   * by the IDAInterface stepper.
+   */
   std::function<typename LAC::VectorType&()> differential_components;
 
+  /**
+   * Return a vector whose components are the weights used by
+   * IDA to compute the norm. By default this function is not
+   * implemented.
+   */
   std::function<typename LAC::VectorType&()> get_local_tolerances;
 
+  /**
+   * Return a vector which is a lumped mass matrix. This function
+   * is used by Kinsol (through imex) for setting the weights used
+   * for computing the norm a vector.
+   */
   std::function<typename LAC::VectorType&()> get_lumped_mass_matrix;
 
+  /**
+   * Compute the matrix-vector product Jacobian times @p src,
+   * and the result is put in @p dst.
+   */
   std::function<int(const typename LAC::VectorType &src,
                     typename LAC::VectorType &dst)> jacobian_vmult;
 

--- a/include/pidomus_lambdas.h
+++ b/include/pidomus_lambdas.h
@@ -83,6 +83,9 @@ public:
 
   std::function<typename LAC::VectorType&()> get_lumped_mass_matrix;
 
+  std::function<int(const typename LAC::VectorType &src,
+                    typename LAC::VectorType &dst)> jacobian_vmult;
+
   /**
    * A pointer to the simulator object to which we want to get
    * access.

--- a/include/simulator_access.h
+++ b/include/simulator_access.h
@@ -31,7 +31,7 @@ public:
   SimulatorAccess ();
 
   /**
-   * Create a piDoMUSAccess object that is already initialized for
+   * Create a SimulatorAccess object that is already initialized for
    * a particular piDoMUS.
    */
   SimulatorAccess (const piDoMUS<dim,spacedim,LAC> &simulator_object);

--- a/include/simulator_access.h
+++ b/include/simulator_access.h
@@ -73,11 +73,13 @@ public:
   Signals<dim,spacedim,LAC> &
   get_signals() const;
 
+#ifdef DEAL_II_WITH_MPI
   /**
    * Return the MPI communicator for this simulation.
    */
   MPI_Comm
   get_mpi_communicator () const;
+#endif
 
   /**
    * Return a reference to the stream object that only outputs something

--- a/source/base_interface.cc
+++ b/source/base_interface.cc
@@ -552,6 +552,15 @@ void
 BaseInterface<dim,spacedim,LAC>::connect_to_signals() const
 {}
 
+template<int dim, int spacedim, typename LAC>
+double
+BaseInterface<dim,spacedim,LAC>::
+vector_norm (const typename LAC::VectorType &v) const
+{
+  return v.l2_norm();
+}
+
+
 #define INSTANTIATE(dim,spacedim,LAC) \
   template class BaseInterface<dim,spacedim,LAC>;
 

--- a/source/pidomus.cc
+++ b/source/pidomus.cc
@@ -99,7 +99,7 @@ piDoMUS<dim, spacedim, LAC>::piDoMUS (const std::string &name,
 
 
   ida("IDA Solver Parameters", comm),
-  imex(*this),
+  imex("IMEX Parameters", comm),
   we_are_parallel(Utilities::MPI::n_mpi_processes(comm) > 1),
   lambdas(*this)
 {
@@ -137,6 +137,7 @@ void piDoMUS<dim, spacedim, LAC>::run ()
 
       constraints.distribute(solution);
       constraints_dot.distribute(solution_dot);
+      std::cout << "1111111111111111111111111111" << std::endl << std::flush;
 
       if (time_stepper == "ida")
         {
@@ -152,6 +153,15 @@ void piDoMUS<dim, spacedim, LAC>::run ()
       else if (time_stepper == "euler" || time_stepper == "imex")
         {
           current_alpha = imex.get_alpha();
+          imex.create_new_vector = lambdas.create_new_vector;
+          imex.residual = lambdas.residual;
+          imex.setup_jacobian = lambdas.setup_jacobian;
+          std::cout << "5555555555555555555555555555" << std::endl << std::flush;
+          imex.solver_should_restart = lambdas.solver_should_restart;
+          imex.solve_jacobian_system = lambdas.solve_jacobian_system;
+          imex.output_step = lambdas.output_step;
+          imex.get_lumped_mass_matrix = lambdas.get_lumped_mass_matrix;
+          std::cout << "2222222222222222222222222" << std::endl << std::flush;
           imex.solve_dae(solution, solution_dot);
         }
       eh.error_from_exact(interface.get_error_mapping(), *dof_handler, locally_relevant_solution, exact_solution);

--- a/source/pidomus.cc
+++ b/source/pidomus.cc
@@ -156,12 +156,11 @@ void piDoMUS<dim, spacedim, LAC>::run ()
           imex.create_new_vector = lambdas.create_new_vector;
           imex.residual = lambdas.residual;
           imex.setup_jacobian = lambdas.setup_jacobian;
-          std::cout << "5555555555555555555555555555" << std::endl << std::flush;
           imex.solver_should_restart = lambdas.solver_should_restart;
           imex.solve_jacobian_system = lambdas.solve_jacobian_system;
           imex.output_step = lambdas.output_step;
           imex.get_lumped_mass_matrix = lambdas.get_lumped_mass_matrix;
-          std::cout << "2222222222222222222222222" << std::endl << std::flush;
+          imex.jacobian_vmult = lambdas.jacobian_vmult;
           imex.solve_dae(solution, solution_dot);
         }
       eh.error_from_exact(interface.get_error_mapping(), *dof_handler, locally_relevant_solution, exact_solution);

--- a/source/pidomus.cc
+++ b/source/pidomus.cc
@@ -47,7 +47,6 @@ piDoMUS<dim, spacedim, LAC>::piDoMUS (const std::string &name,
                                       const MPI_Comm communicator)
   :
   ParameterAcceptor(name),
-  SundialsInterface<typename LAC::VectorType>(communicator),
   comm(Utilities::MPI::duplicate_communicator(communicator)),
   interface(interface),
   pcout (std::cout,
@@ -137,7 +136,6 @@ void piDoMUS<dim, spacedim, LAC>::run ()
 
       constraints.distribute(solution);
       constraints_dot.distribute(solution_dot);
-      std::cout << "1111111111111111111111111111" << std::endl << std::flush;
 
       if (time_stepper == "ida")
         {
@@ -312,12 +310,7 @@ void piDoMUS<dim, spacedim, LAC>::setup_dofs (const bool &first_run)
 
 template <int dim, int spacedim, typename LAC>
 int
-piDoMUS<dim, spacedim, LAC>::solve_jacobian_system(const double /*t*/,
-                                                   const typename LAC::VectorType &/*y*/,
-                                                   const typename LAC::VectorType &/*y_dot*/,
-                                                   const typename LAC::VectorType &,
-                                                   const double /*alpha*/,
-                                                   const typename LAC::VectorType &src,
+piDoMUS<dim, spacedim, LAC>::solve_jacobian_system(const typename LAC::VectorType &src,
                                                    typename LAC::VectorType &dst) const
 {
   auto _timer = computing_timer.scoped_timer ("Solve system");

--- a/source/pidomus_assemble.cc
+++ b/source/pidomus_assemble.cc
@@ -20,7 +20,6 @@ int
 piDoMUS<dim, spacedim, LAC>::setup_jacobian(const double t,
                                             const typename LAC::VectorType &src_yy,
                                             const typename LAC::VectorType &src_yp,
-                                            const typename LAC::VectorType &,
                                             const double alpha)
 {
   signals.begin_setup_jacobian();

--- a/source/pidomus_eigen.cc
+++ b/source/pidomus_eigen.cc
@@ -96,7 +96,7 @@ void piDoMUS<dim, spacedim, LAC>::solve_eigenproblem()
 
       mass_matrix.reinit(mass_pattern);
 
-      setup_jacobian(current_time,solution,solution_dot,solution_dot,current_alpha);
+      setup_jacobian(current_time,solution,solution_dot,current_alpha);
 
       // assemble mass matrix
       const QGauss<dim> quadrature_formula(fe->degree + 1);

--- a/source/pidomus_helper_functions.cc
+++ b/source/pidomus_helper_functions.cc
@@ -216,8 +216,7 @@ void
 piDoMUS<dim, spacedim, LAC>::output_step(const double  t,
                                          const typename LAC::VectorType &solution,
                                          const typename LAC::VectorType &solution_dot,
-                                         const unsigned int step_number,
-                                         const double // h
+                                         const unsigned int step_number
                                         )
 {
   auto _timer = computing_timer.scoped_timer ("Postprocessing");

--- a/source/pidomus_helper_functions.cc
+++ b/source/pidomus_helper_functions.cc
@@ -17,6 +17,12 @@ piDoMUS<dim, spacedim, LAC>::create_new_vector() const
   return ret;
 }
 
+template <int dim, int spacedim, typename LAC>
+double
+piDoMUS<dim, spacedim, LAC>::vector_norm(const typename LAC::VectorType &v) const
+{
+  return interface.vector_norm(v);
+}
 
 template <int dim, int spacedim, typename LAC>
 unsigned int

--- a/source/pidomus_lambdas.cc
+++ b/source/pidomus_lambdas.cc
@@ -1,0 +1,105 @@
+#include "pidomus_lambdas.h"
+#include "pidomus.h"
+#include "pidomus_macros.h"
+
+template <int dim, int spacedim, typename LAC>
+Lambdas<dim,spacedim,LAC>::Lambdas ()
+{}
+
+
+template <int dim, int spacedim, typename LAC>
+Lambdas<dim,spacedim,LAC>::
+Lambdas (piDoMUS<dim,spacedim,LAC> &simulator_object)
+  :
+  simulator (&simulator_object)
+{}
+
+
+template <int dim, int spacedim, typename LAC>
+Lambdas<dim,spacedim,LAC>::~Lambdas ()
+{}
+
+
+template <int dim, int spacedim, typename LAC>
+void
+Lambdas<dim,spacedim,LAC>::
+initialize_simulator (piDoMUS<dim,spacedim,LAC> &simulator_object)
+{
+  simulator = &simulator_object;
+}
+
+
+template <int dim, int spacedim, typename LAC>
+void
+Lambdas<dim,spacedim,LAC>::
+set_functions_to_default()
+{
+  create_new_vector = [this]() ->shared_ptr<typename LAC::VectorType>
+  {
+    return this->simulator->create_new_vector();
+  };
+
+  residual = [this](const double t,
+                    const typename LAC::VectorType &y,
+                    const typename LAC::VectorType &y_dot,
+                    typename LAC::VectorType &residual) ->int
+  {
+    return this->simulator->residual(t,y,y_dot,residual);
+  };
+
+  setup_jacobian = [this](const double t,
+                          const typename LAC::VectorType &y,
+                          const typename LAC::VectorType &y_dot,
+                          const double alpha) ->int
+  {
+    shared_ptr<typename LAC::VectorType> res;
+    return this->simulator->setup_jacobian(t,y,y_dot,*res,alpha);
+  };
+
+  solve_jacobian_system = [this](const typename LAC::VectorType &rhs,
+                                 typename LAC::VectorType &dst) ->int
+  {
+    shared_ptr<typename LAC::VectorType> y;
+    shared_ptr<typename LAC::VectorType> y_d;
+    shared_ptr<typename LAC::VectorType> re;
+    return this->simulator->solve_jacobian_system(0,*y,*y_d,*re,0,rhs,dst);
+  };
+
+  output_step = [this](const double t,
+                       const typename LAC::VectorType &y,
+                       const typename LAC::VectorType &y_dot,
+                       const unsigned int step_number)
+  {
+    this->simulator->output_step(t,y,y_dot,step_number,0);
+  };
+
+  solver_should_restart = [this](const double t,
+                                 typename LAC::VectorType &y,
+                                 typename LAC::VectorType &y_dot) ->bool
+  {
+    return this->simulator->solver_should_restart(t,0,0,y,y_dot);
+  };
+
+  differential_components = [this]() ->typename LAC::VectorType &
+  {
+    return this->simulator->differential_components();
+  };
+
+  get_local_tolerances = [this]() ->typename LAC::VectorType &
+  {
+    return this->simulator->get_local_tolerances();
+  };
+
+  get_lumped_mass_matrix = [this]() ->typename LAC::VectorType &
+  {
+    auto lm = this->create_new_vector();
+    this->simulator->get_lumped_mass_matrix(*lm);
+    return *lm;
+  };
+
+}
+
+#define INSTANTIATE(dim,spacedim,LAC) \
+  template class Lambdas<dim,spacedim,LAC>;
+
+PIDOMUS_INSTANTIATE(INSTANTIATE)

--- a/source/pidomus_lambdas.cc
+++ b/source/pidomus_lambdas.cc
@@ -90,9 +90,9 @@ set_functions_to_default()
     return this->simulator->get_local_tolerances();
   };
 
-  get_lumped_mass_matrix = [this]() ->typename LAC::VectorType &
+  get_lumped_mass_matrix = [&]() ->typename LAC::VectorType &
   {
-    auto lm = this->create_new_vector();
+    static auto lm = this->create_new_vector();
     this->simulator->get_lumped_mass_matrix(*lm);
     return *lm;
   };
@@ -100,8 +100,8 @@ set_functions_to_default()
   jacobian_vmult = [this](const typename LAC::VectorType &src,
                           typename LAC::VectorType &dst) ->int
   {
-      return this->simulator->jacobian_vmult(src,dst);
-    };
+    return this->simulator->jacobian_vmult(src,dst);
+  };
 
 }
 

--- a/source/pidomus_lambdas.cc
+++ b/source/pidomus_lambdas.cc
@@ -101,6 +101,11 @@ set_functions_to_default()
     return this->simulator->jacobian_vmult(src,dst);
   };
 
+  vector_norm = [this](const typename LAC::VectorType &vector) ->double
+  {
+    return this->simulator->vector_norm(vector);
+  };
+
 }
 
 #define INSTANTIATE(dim,spacedim,LAC) \

--- a/source/pidomus_lambdas.cc
+++ b/source/pidomus_lambdas.cc
@@ -90,7 +90,8 @@ set_functions_to_default()
 
   get_lumped_mass_matrix = [&]() ->typename LAC::VectorType &
   {
-    static auto lm = this->create_new_vector();
+    static shared_ptr<typename LAC::VectorType> lm;
+    lm = this->create_new_vector();
     this->simulator->get_lumped_mass_matrix(*lm);
     return *lm;
   };

--- a/source/pidomus_lambdas.cc
+++ b/source/pidomus_lambdas.cc
@@ -97,6 +97,12 @@ set_functions_to_default()
     return *lm;
   };
 
+  jacobian_vmult = [this](const typename LAC::VectorType &src,
+                          typename LAC::VectorType &dst) ->int
+  {
+      return this->simulator->jacobian_vmult(src,dst);
+    };
+
 }
 
 #define INSTANTIATE(dim,spacedim,LAC) \

--- a/source/pidomus_lambdas.cc
+++ b/source/pidomus_lambdas.cc
@@ -52,17 +52,13 @@ set_functions_to_default()
                           const typename LAC::VectorType &y_dot,
                           const double alpha) ->int
   {
-    shared_ptr<typename LAC::VectorType> res;
-    return this->simulator->setup_jacobian(t,y,y_dot,*res,alpha);
+    return this->simulator->setup_jacobian(t,y,y_dot,alpha);
   };
 
   solve_jacobian_system = [this](const typename LAC::VectorType &rhs,
                                  typename LAC::VectorType &dst) ->int
   {
-    shared_ptr<typename LAC::VectorType> y;
-    shared_ptr<typename LAC::VectorType> y_d;
-    shared_ptr<typename LAC::VectorType> re;
-    return this->simulator->solve_jacobian_system(0,*y,*y_d,*re,0,rhs,dst);
+    return this->simulator->solve_jacobian_system(rhs,dst);
   };
 
   output_step = [this](const double t,
@@ -70,14 +66,14 @@ set_functions_to_default()
                        const typename LAC::VectorType &y_dot,
                        const unsigned int step_number)
   {
-    this->simulator->output_step(t,y,y_dot,step_number,0);
+    this->simulator->output_step(t,y,y_dot,step_number);
   };
 
   solver_should_restart = [this](const double t,
                                  typename LAC::VectorType &y,
                                  typename LAC::VectorType &y_dot) ->bool
   {
-    return this->simulator->solver_should_restart(t,0,0,y,y_dot);
+    return this->simulator->solver_should_restart(t,y,y_dot);
   };
 
   differential_components = [this]() ->typename LAC::VectorType &
@@ -87,7 +83,9 @@ set_functions_to_default()
 
   get_local_tolerances = [this]() ->typename LAC::VectorType &
   {
-    return this->simulator->get_local_tolerances();
+    AssertThrow(false, ExcPureFunctionCalled("Please implement get_local_tolerances function."));
+    static auto lt = this->create_new_vector();
+    return *lt;
   };
 
   get_lumped_mass_matrix = [&]() ->typename LAC::VectorType &

--- a/source/pidomus_mesh_refinement.cc
+++ b/source/pidomus_mesh_refinement.cc
@@ -50,8 +50,6 @@ void piDoMUS<dim, spacedim, LAC>::refine_mesh ()
 template <int dim, int spacedim, typename LAC>
 bool
 piDoMUS<dim, spacedim, LAC>::solver_should_restart(const double t,
-                                                   const unsigned int /*step_number*/,
-                                                   const double /*h*/,
                                                    typename LAC::VectorType &solution,
                                                    typename LAC::VectorType &solution_dot)
 {

--- a/source/pidomus_parameters.cc
+++ b/source/pidomus_parameters.cc
@@ -63,7 +63,7 @@ declare_parameters (ParameterHandler &prm)
   add_parameter(  prm,
                   &time_stepper,
                   "Time stepper",
-                  "euler",
+                  "imex",
                   Patterns::Selection("ida|euler|imex")); //imex
 
   add_parameter(  prm,

--- a/source/pidomus_parameters.cc
+++ b/source/pidomus_parameters.cc
@@ -25,12 +25,6 @@ declare_parameters (ParameterHandler &prm)
                   Patterns::Integer (0));
 
   add_parameter(  prm,
-                  &max_time_iterations,
-                  "Maximum number of time steps",
-                  "10000",
-                  Patterns::Integer (0));
-
-  add_parameter(  prm,
                   &jacobian_solver_tolerance,
                   "Jacobian solver tolerance",
                   "1e-8",

--- a/source/simulator_access.cc
+++ b/source/simulator_access.cc
@@ -47,12 +47,14 @@ SimulatorAccess<dim,spacedim,LAC>::get_signals() const
 }
 
 
-
+#ifdef DEAL_II_WITH_MPI
 template <int dim, int spacedim, typename LAC>
 MPI_Comm SimulatorAccess<dim,spacedim,LAC>::get_mpi_communicator () const
 {
   return simulator->comm;
 }
+#endif
+
 
 template <int dim, int spacedim, typename LAC>
 const ConditionalOStream &

--- a/tests/parameters/arpack_01.prm
+++ b/tests/parameters/arpack_01.prm
@@ -156,7 +156,6 @@ subsection pidomus
   set Max iterations finer prec.                     = 0
   set Max tmp vectors                                = 30
   set Max tmp vectors for finer system               = 50
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Number of eigenvalues to compute               = 12
   set Number of used Arnoldi vectors                 = 0

--- a/tests/parameters/cahn_hilliard_01.prm
+++ b/tests/parameters/cahn_hilliard_01.prm
@@ -138,7 +138,6 @@ subsection pidomus
   set Adaptive refinement                            = true
   set Initial global refinement                      = 5
   set Jacobian solver tolerance                      = 1e-8
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/compressible_neo_hookean_01.prm
+++ b/tests/parameters/compressible_neo_hookean_01.prm
@@ -131,7 +131,6 @@ end
 subsection piDoMUS<3, 3, LATrilinos>
   set Adaptive refinement                            = true
   set Initial global refinement                      = 1
-  set Maximum number of time steps                   = 10000
   set Jacobian solver tolerance                      = 1e-8
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true

--- a/tests/parameters/compressible_neo_hookean_02.prm
+++ b/tests/parameters/compressible_neo_hookean_02.prm
@@ -131,7 +131,6 @@ end
 subsection piDoMUS<3, 3, LATrilinos>
   set Adaptive refinement                            = true
   set Initial global refinement                      = 1
-  set Maximum number of time steps                   = 10000
   set Jacobian solver tolerance                      = 1e-8
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true

--- a/tests/parameters/compressible_neo_hookean_03.prm
+++ b/tests/parameters/compressible_neo_hookean_03.prm
@@ -131,7 +131,6 @@ end
 subsection piDoMUS<3, 3, LADealII>
   set Adaptive refinement                            = true
   set Initial global refinement                      = 1
-  set Maximum number of time steps                   = 10000
   set Jacobian solver tolerance                      = 1e-8
   set Number of cycles                               = 3
   set Overwrite Newton's iterations                  = true

--- a/tests/parameters/compressible_neo_hookean_04.prm
+++ b/tests/parameters/compressible_neo_hookean_04.prm
@@ -156,7 +156,6 @@ subsection piDoMUS<3, 3, LADealII>
   set Jacobian solver tolerance                      = 1e-8
   set Max iterations                                 = 50
   set Max iterations finer prec.                     = 0
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/compressible_neo_hookean_05.prm
+++ b/tests/parameters/compressible_neo_hookean_05.prm
@@ -163,7 +163,6 @@ subsection piDoMUS<3, 3, LATrilinos>
   set Jacobian solver tolerance                      = 1e-8
   set Max iterations                                 = 50
   set Max iterations finer prec.                     = 0
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = false
   set Print some useful informations about processes = true

--- a/tests/parameters/dynamic_stokes_00.prm
+++ b/tests/parameters/dynamic_stokes_00.prm
@@ -7,7 +7,6 @@
 subsection piDoMUS<2, 2, LADealII>
   set Adaptive refinement                            = false
   set Initial global refinement                      = 4
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = false

--- a/tests/parameters/dynamic_stokes_01.prm
+++ b/tests/parameters/dynamic_stokes_01.prm
@@ -7,7 +7,6 @@
 subsection piDoMUS<2, 2, LADealII>
   set Adaptive refinement                            = false
   set Initial global refinement                      = 4
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = false

--- a/tests/parameters/dynamic_stokes_02.prm
+++ b/tests/parameters/dynamic_stokes_02.prm
@@ -7,7 +7,6 @@
 subsection piDoMUS<2, 2, LATrilinos>
   set Adaptive refinement                            = false
   set Initial global refinement                      = 1
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 3
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = false

--- a/tests/parameters/eikonal_equation_01.prm
+++ b/tests/parameters/eikonal_equation_01.prm
@@ -124,7 +124,6 @@ subsection pidomus
   set Max iterations finer prec.                     = 20
   set Max tmp vectors                                = 30
   set Max tmp vectors for finer system               = 50
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = false
   set Print some useful informations about processes = true

--- a/tests/parameters/eikonal_equation_02.prm
+++ b/tests/parameters/eikonal_equation_02.prm
@@ -111,7 +111,6 @@ subsection pidomus
   set Max iterations finer prec.                     = 20
   set Max tmp vectors                                = 30
   set Max tmp vectors for finer system               = 50
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = false
   set Print some useful informations about processes = true

--- a/tests/parameters/eikonal_equation_03.prm
+++ b/tests/parameters/eikonal_equation_03.prm
@@ -111,7 +111,6 @@ subsection pidomus
   set Max iterations finer prec.                     = 20
   set Max tmp vectors                                = 30
   set Max tmp vectors for finer system               = 50
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = false
   set Print some useful informations about processes = true

--- a/tests/parameters/eikonal_equation_04.prm
+++ b/tests/parameters/eikonal_equation_04.prm
@@ -111,7 +111,6 @@ subsection pidomus
   set Max iterations finer prec.                     = 20
   set Max tmp vectors                                = 30
   set Max tmp vectors for finer system               = 50
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = false
   set Print some useful informations about processes = true

--- a/tests/parameters/hydrogels_one_field_01.prm
+++ b/tests/parameters/hydrogels_one_field_01.prm
@@ -141,7 +141,6 @@ subsection piDoMUS
   set Adaptive refinement                            = true
   set Initial global refinement                      = 0
   set Jacobian solver tolerance                      = 1e-8
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/hydrogels_one_field_02.prm
+++ b/tests/parameters/hydrogels_one_field_02.prm
@@ -141,7 +141,6 @@ subsection piDoMUS
   set Adaptive refinement                            = true
   set Initial global refinement                      = 0
   set Jacobian solver tolerance                      = 1e-8
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/hydrogels_three_fields_01.prm
+++ b/tests/parameters/hydrogels_three_fields_01.prm
@@ -159,7 +159,6 @@ subsection piDoMUS
   set Adaptive refinement                            = true
   set Initial global refinement                      = 0
   set Jacobian solver tolerance                      = 1e-8
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/hydrogels_three_fields_02.prm
+++ b/tests/parameters/hydrogels_three_fields_02.prm
@@ -185,7 +185,6 @@ subsection piDoMUS
   set Jacobian solver tolerance                      = 1e-13
   set Max iterations                                 = 50
   set Max iterations finer prec.                     = 0
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = false
   set Print some useful informations about processes = true

--- a/tests/parameters/hydrogels_three_fields_03.prm
+++ b/tests/parameters/hydrogels_three_fields_03.prm
@@ -199,7 +199,6 @@ subsection piDoMUS
   set Max iterations finer prec.                     = 0
   set Max tmp vectors                                = 30
   set Max tmp vectors for finer system               = 50
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Number of eigenvalues to compute               = 10
   set Number of used Arnoldi vectors                 = 0

--- a/tests/parameters/hydrogels_three_fields_03.prm
+++ b/tests/parameters/hydrogels_three_fields_03.prm
@@ -1,8 +1,8 @@
 # Parameter file generated with 
-# D2K_GIT_BRANCH=       kinsol_implementation
-# D2K_GIT_SHORTREV=     f667f6f
+# D2K_GIT_BRANCH=       rev-sundials
+# D2K_GIT_SHORTREV=     6327a95
 # DEAL_II_GIT_BRANCH=   master
-# DEAL_II_GIT_SHORTREV= b3f2eeb
+# DEAL_II_GIT_SHORTREV= eb652bf
 subsection AMG for U
   set Aggregation threshold              = 0.000100
   set Coarse type                        = Amesos-KLU
@@ -91,6 +91,8 @@ subsection Free Swelling Three Fields
   set Omega                            = 1e-5
   set T                                = 298.0
   set chi                              = 0.1
+  set distort triangulation            = false
+  set distortion factor                = 1e-4
   set iteration c lumped               = 10
   set iteration s                      = 10
   set iteration s approx               = 10
@@ -195,13 +197,17 @@ subsection piDoMUS
   set Jacobian solver tolerance                      = 1e-8
   set Max iterations                                 = 50
   set Max iterations finer prec.                     = 0
+  set Max tmp vectors                                = 30
+  set Max tmp vectors for finer system               = 50
   set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
+  set Number of eigenvalues to compute               = 10
+  set Number of used Arnoldi vectors                 = 0
   set Overwrite Newton's iterations                  = false
   set Print some useful informations about processes = true
   set Refine mesh during transient                   = false
-  set Show timer                                     = true
   set Threshold for solver's restart                 = 1e-2
   set Time stepper                                   = euler
   set Use direct solver if available                 = true
+  set Which eigenvalues                              = smallest_real_part
 end

--- a/tests/parameters/hydrogels_two_fields_transient_01.prm
+++ b/tests/parameters/hydrogels_two_fields_transient_01.prm
@@ -136,7 +136,6 @@ subsection piDoMUS
   set Adaptive refinement                            = true
   set Initial global refinement                      = 0
   set Jacobian solver tolerance                      = 1e-8
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/incompressible_neo_hookean_two_fields_01.prm
+++ b/tests/parameters/incompressible_neo_hookean_two_fields_01.prm
@@ -130,7 +130,6 @@ end
 subsection piDoMUS<3, 3, LADealII>
   set Adaptive refinement                            = true
   set Initial global refinement                      = 1
-  set Maximum number of time steps                   = 10000
   set Jacobian solver tolerance                      = 1e-8
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true

--- a/tests/parameters/incompressible_neo_hookean_two_fields_02.prm
+++ b/tests/parameters/incompressible_neo_hookean_two_fields_02.prm
@@ -130,7 +130,6 @@ end
 subsection piDoMUS<3, 3, LATrilinos>
   set Adaptive refinement                            = true
   set Initial global refinement                      = 1
-  set Maximum number of time steps                   = 10000
   set Jacobian solver tolerance                      = 1e-8
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true

--- a/tests/parameters/incompressible_neo_hookean_two_fields_03.prm
+++ b/tests/parameters/incompressible_neo_hookean_two_fields_03.prm
@@ -162,7 +162,6 @@ subsection piDoMUS<3, 3, LADealII>
   set Jacobian solver tolerance                      = 1e-8
   set Max iterations                                 = 50
   set Max iterations finer prec.                     = 0
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/k_omega_00.prm
+++ b/tests/parameters/k_omega_00.prm
@@ -30,7 +30,6 @@ end
 subsection piDoMUS<2, 2, LADealII>
   set Adaptive refinement                            = false
   set Initial global refinement                      = 4
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/navier_stokes_00.prm
+++ b/tests/parameters/navier_stokes_00.prm
@@ -55,7 +55,6 @@ end
 subsection piDoMUS<2, 2, LADealII>
   set Adaptive refinement                            = false
   set Initial global refinement                      = 4
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/navier_stokes_01.prm
+++ b/tests/parameters/navier_stokes_01.prm
@@ -55,7 +55,6 @@ end
 subsection piDoMUS<2, 2, LATrilinos>
   set Adaptive refinement                            = false
   set Initial global refinement                      = 3
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/navier_stokes_02.prm
+++ b/tests/parameters/navier_stokes_02.prm
@@ -199,7 +199,6 @@ subsection piDoMUS<2, 2, LATrilinos>
   set Jacobian solver tolerance                      = 1e-6
   set Max iterations                                 = 50
   set Max iterations finer prec.                     = 0
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 3
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/navier_stokes_03.prm
+++ b/tests/parameters/navier_stokes_03.prm
@@ -56,7 +56,6 @@ end
 subsection piDoMUS<2, 2, LATrilinos>
   set Adaptive refinement                            = false
   set Initial global refinement                      = 3
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/navier_stokes_04.prm
+++ b/tests/parameters/navier_stokes_04.prm
@@ -56,7 +56,6 @@ end
 subsection piDoMUS<2, 2, LATrilinos>
   set Adaptive refinement                            = false
   set Initial global refinement                      = 3
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/navier_stokes_05.prm
+++ b/tests/parameters/navier_stokes_05.prm
@@ -200,7 +200,6 @@ subsection piDoMUS<2, 2, LATrilinos>
   set Jacobian solver tolerance                      = 1e-6
   set Max iterations                                 = 50
   set Max iterations finer prec.                     = 0
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 3
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/parpack_01.prm
+++ b/tests/parameters/parpack_01.prm
@@ -156,7 +156,6 @@ subsection pidomus
   set Max iterations finer prec.                     = 0
   set Max tmp vectors                                = 30
   set Max tmp vectors for finer system               = 50
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Number of eigenvalues to compute               = 12
   set Number of used Arnoldi vectors                 = 0

--- a/tests/parameters/poisson_nitsche_01.prm
+++ b/tests/parameters/poisson_nitsche_01.prm
@@ -145,7 +145,6 @@ subsection pidomus
   set Adaptive refinement                            = true
   set Initial global refinement                      = 1
   set Jacobian solver tolerance                      = 1e-8
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/poisson_problem_01.prm
+++ b/tests/parameters/poisson_problem_01.prm
@@ -129,7 +129,6 @@ end
 subsection pidomus
   set Adaptive refinement                            = true
   set Initial global refinement                      = 1
-  set Maximum number of time steps                   = 10000
   set Jacobian solver tolerance                      = 1e-8
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true

--- a/tests/parameters/poisson_problem_02.prm
+++ b/tests/parameters/poisson_problem_02.prm
@@ -129,7 +129,6 @@ end
 subsection pidomus
   set Adaptive refinement                            = true
   set Initial global refinement                      = 1
-  set Maximum number of time steps                   = 10000
   set Jacobian solver tolerance                      = 1e-8
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true

--- a/tests/parameters/poisson_problem_03.prm
+++ b/tests/parameters/poisson_problem_03.prm
@@ -138,7 +138,6 @@ subsection pidomus
   set Adaptive refinement                            = true
   set Initial global refinement                      = 1
   set Jacobian solver tolerance                      = 1e-8
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/stokes_00.prm
+++ b/tests/parameters/stokes_00.prm
@@ -7,7 +7,6 @@
 subsection piDoMUS<2, 2, LADealII>
   set Adaptive refinement                            = false
   set Initial global refinement                      = 1
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 3
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/stokes_01.prm
+++ b/tests/parameters/stokes_01.prm
@@ -7,7 +7,6 @@
 subsection piDoMUS<2, 2, LADealII>
   set Adaptive refinement                            = false
   set Initial global refinement                      = 4
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/tests/parameters/stokes_02.prm
+++ b/tests/parameters/stokes_02.prm
@@ -8,7 +8,6 @@ subsection piDoMUS<2, 2, LATrilinos>
   set Jacobian solver tolerance                      = 1e-12
   set Adaptive refinement                            = false
   set Initial global refinement                      = 5
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/utilities/prm/hydrogels/constrained-swelling-one-field.prm
+++ b/utilities/prm/hydrogels/constrained-swelling-one-field.prm
@@ -94,7 +94,6 @@ subsection piDoMUS
   set Jacobian solver tolerance                      = 1e-8
   set Max iterations                                 = 50
   set Max iterations finer prec.                     = 0
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/utilities/prm/hydrogels/constrained-swelling-three-fields.prm
+++ b/utilities/prm/hydrogels/constrained-swelling-three-fields.prm
@@ -108,7 +108,6 @@ subsection piDoMUS
   set Jacobian solver tolerance                      = 1e-8
   set Max iterations                                 = 0
   set Max iterations finer prec.                     = 0
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/utilities/prm/hydrogels/free-swelling-one-field.prm
+++ b/utilities/prm/hydrogels/free-swelling-one-field.prm
@@ -94,7 +94,6 @@ subsection piDoMUS
   set Jacobian solver tolerance                      = 1e-8
   set Max iterations                                 = 50
   set Max iterations finer prec.                     = 0
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/utilities/prm/hydrogels/free-swelling-three-fields.prm
+++ b/utilities/prm/hydrogels/free-swelling-three-fields.prm
@@ -108,7 +108,6 @@ subsection piDoMUS
   set Jacobian solver tolerance                      = 1e-8
   set Max iterations                                 = 50
   set Max iterations finer prec.                     = 0
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/utilities/prm/hydrogels/wrinkling-one-field.prm
+++ b/utilities/prm/hydrogels/wrinkling-one-field.prm
@@ -161,7 +161,6 @@ subsection piDoMUS
   set Jacobian solver tolerance                      = 1e-8
   set Max iterations                                 = 50
   set Max iterations finer prec.                     = 0
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/utilities/prm/hydrogels/wrinkling-three-fields.prm
+++ b/utilities/prm/hydrogels/wrinkling-three-fields.prm
@@ -197,7 +197,6 @@ subsection piDoMUS
   set Jacobian solver tolerance                      = 1e-8
   set Max iterations                                 = 1000
   set Max iterations finer prec.                     = 0
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = false
   set Print some useful informations about processes = true

--- a/utilities/prm/navier_stokes/ALE_test.prm
+++ b/utilities/prm/navier_stokes/ALE_test.prm
@@ -90,7 +90,6 @@ subsection piDoMUS
   set Max iterations finer prec.                     = 0
   set Max tmp vectors                                = 30
   set Max tmp vectors for finer system               = 50
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Number of eigenvalues to compute               = 10
   set Number of used Arnoldi vectors                 = 0

--- a/utilities/prm/navier_stokes/default.prm
+++ b/utilities/prm/navier_stokes/default.prm
@@ -533,7 +533,6 @@ end
 subsection piDoMUS<2, 2, 3, LATrilinos>
   set Adaptive refinement            = true
   set Initial global refinement      = 1
-  set Maximum number of time steps   = 10000
   set Number of cycles               = 3
   set Show timer                     = false
   set Use direct solver if available = true

--- a/utilities/prm/navier_stokes/flow_past_a_cylinder_2D_00.prm
+++ b/utilities/prm/navier_stokes/flow_past_a_cylinder_2D_00.prm
@@ -38,7 +38,6 @@ subsection piDoMUS
   set Max iterations finer prec.                     = 0
   
   set Initial global refinement                      = 4
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = false
   set Print some useful informations about processes = true

--- a/utilities/prm/navier_stokes/flow_past_a_cylinder_2D_01.prm
+++ b/utilities/prm/navier_stokes/flow_past_a_cylinder_2D_01.prm
@@ -39,7 +39,6 @@ subsection piDoMUS
 
   set Initial global refinement                      = 4
   
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = false
   set Print some useful informations about processes = true

--- a/utilities/prm/navier_stokes/flow_past_a_cylinder_3D.prm
+++ b/utilities/prm/navier_stokes/flow_past_a_cylinder_3D.prm
@@ -62,7 +62,6 @@ subsection piDoMUS
   set Max iterations finer prec.                     = 30
   
   set Jacobian solver tolerance                      = 1e-5
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true

--- a/utilities/prm/navier_stokes/flow_past_two_cylinders.prm
+++ b/utilities/prm/navier_stokes/flow_past_two_cylinders.prm
@@ -12,7 +12,6 @@ subsection piDoMUS
   set Adaptive refinement                            = true
   set Initial global refinement                      = 0
   set Jacobian solver tolerance                      = 1e-6
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = false
   set Print some useful informations about processes = true

--- a/utilities/prm/navier_stokes/lid_cavity_2D.prm
+++ b/utilities/prm/navier_stokes/lid_cavity_2D.prm
@@ -38,7 +38,6 @@ subsection piDoMUS
   set Max iterations                                 = 100
   set Max iterations finer prec.                     = 50
   
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = false
   set Print some useful informations about processes = true

--- a/utilities/prm/navier_stokes/lid_cavity_3D.prm
+++ b/utilities/prm/navier_stokes/lid_cavity_3D.prm
@@ -37,7 +37,6 @@ subsection piDoMUS
   set Max iterations                                 = 50
   set Max iterations finer prec.                     = 0
   
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = false
   set Print some useful informations about processes = true

--- a/utilities/prm/turbulence/k_omega_2D.prm
+++ b/utilities/prm/turbulence/k_omega_2D.prm
@@ -203,7 +203,6 @@ subsection piDoMUS
   set Refine mesh during transient                   = false
   set Threshold for solver's restart                 = 1e-2
   
-  set Maximum number of time steps                   = 10000
   set Number of cycles                               = 1
   set Overwrite Newton's iterations                  = true
   set Print some useful informations about processes = true


### PR DESCRIPTION
IMEX and IDA have public std::functions that must be implemented by the user. I've added a class named `Lambdas` (better name suggestions?) which implements all the `std::functions` (e.g., residual, setup_jacobian, solve_linear_system,...) and by defaults these functions call the namesake functions of piDoMUS. This allows greater flexibility. Indeed, when the signals are not enough, a specific function can be completly rewritten as follows

```
Interface<2,2> problem();
piDoMUS<2,2> pidomus("pidomus",problem);
pidomus.lambdas.setup_jacobian = [...](...) ->...
{
...
};
...
pidomus.run();
```
