### PR TITLE
Quick work-around; unused max cells parameter

### DIFF
--- a/include/pidomus.h
+++ b/include/pidomus.h
@@ -442,6 +442,7 @@ private:
   std::vector<IndexSet> relevant_partitioning;
 
   bool adaptive_refinement;
+  unsigned int max_cells;
   const bool we_are_parallel;
   bool use_direct_solver;
 

--- a/source/pidomus_mesh_refinement.cc
+++ b/source/pidomus_mesh_refinement.cc
@@ -82,6 +82,14 @@ piDoMUS<dim, spacedim, LAC>::solver_should_restart(const double t,
                 << max_kelly  << " >  " << kelly_threshold
                 << std::endl
                 << "######################################\n";
+          unsigned int n_active_cells=triangulation->n_active_cells();
+          unsigned int max_cells=this->max_cells;
+          if ((max_cells > 0) & (n_active_cells > max_cells))
+            {
+              pcout << "Maximum number of active cells has already been exceeded." << std::endl;
+              signals.end_solver_should_restart();
+              return false;
+            }
           pgr.mark_cells(estimated_error_per_cell, *triangulation);
 
           refine_and_transfer_solutions(solution,

--- a/source/pidomus_mesh_refinement.cc
+++ b/source/pidomus_mesh_refinement.cc
@@ -77,19 +77,18 @@ piDoMUS<dim, spacedim, LAC>::solver_should_restart(const double t,
       if (max_kelly > kelly_threshold)
 
         {
+          unsigned int n_active_cells=triangulation->n_active_cells();
+          unsigned int max_cells=this->max_cells;
+          if ((max_cells > 0) & (n_active_cells > max_cells))
+            {
+              signals.end_solver_should_restart();
+              return false;
+            }
           pcout << "  ################ restart ######### \n"
                 << "max_kelly > threshold\n"
                 << max_kelly  << " >  " << kelly_threshold
                 << std::endl
                 << "######################################\n";
-          unsigned int n_active_cells=triangulation->n_active_cells();
-          unsigned int max_cells=this->max_cells;
-          if ((max_cells > 0) & (n_active_cells > max_cells))
-            {
-              pcout << "Maximum number of active cells has already been exceeded." << std::endl;
-              signals.end_solver_should_restart();
-              return false;
-            }
           pgr.mark_cells(estimated_error_per_cell, *triangulation);
 
           refine_and_transfer_solutions(solution,

--- a/source/pidomus_parameters.cc
+++ b/source/pidomus_parameters.cc
@@ -42,6 +42,12 @@ declare_parameters (ParameterHandler &prm)
                   "true",
                   Patterns::Bool());
 
+  add_parameter( prm,
+                 &max_cells,
+                 "Max number of cells",
+                 "0",
+                 Patterns::Integer (0));
+
   add_parameter(  prm,
                   &verbose,
                   "Print some useful informations about processes",


### PR DESCRIPTION
This is a work-around for issue #216 .

The 'max number of cells' parameter in the refinement section does not work for my simple code that uses the Poisson problem interface. I have not found the root cause. This commit is a quick work-around that instead:
1. adds a new parameter max_cells to the pi-DoMUS interface.
2. checks the number of active cells against this parameter in should_solver_restart

Such a parameter seems at least as relevant as already existing parameters such as 'kelly threshold' and 'max iterations', so maybe this is actually what we want. This 'work-around' commit violates the concept of 'do not repeat yourself', so I would call this an open issue.
